### PR TITLE
Just a discussion thread

### DIFF
--- a/newIDE/app/src/BrowserApp.js
+++ b/newIDE/app/src/BrowserApp.js
@@ -27,6 +27,7 @@ import DownloadFileStorageProvider from './ProjectsStorage/DownloadFileStoragePr
 import DropboxStorageProvider from './ProjectsStorage/DropboxStorageProvider';
 import OneDriveStorageProvider from './ProjectsStorage/OneDriveStorageProvider';
 import UnsavedChangesContext from './MainFrame/UnsavedChangesContext';
+import CommandsContextProvider from './CommandPanel/context';
 
 export const create = (authentification: Authentification) => {
   Window.setUpContextMenu();
@@ -59,45 +60,47 @@ export const create = (authentification: Authentification) => {
             storageProviders,
             initialFileMetadataToOpen,
           }) => (
-            <UnsavedChangesContext.Consumer>
-              {unsavedChanges => (
-                <MainFrame
-                  i18n={i18n}
-                  eventsFunctionsExtensionsState={
-                    eventsFunctionsExtensionsState
-                  }
-                  renderPreviewLauncher={(props, ref) => (
-                    <BrowserS3PreviewLauncher {...props} ref={ref} />
-                  )}
-                  renderExportDialog={props => (
-                    <ExportDialog
-                      {...props}
-                      exporters={getBrowserExporters()}
-                      allExportersRequireOnline
-                    />
-                  )}
-                  renderCreateDialog={props => (
-                    <CreateProjectDialog
-                      {...props}
-                      examplesComponent={BrowserExamples}
-                      startersComponent={BrowserStarters}
-                    />
-                  )}
-                  introDialog={<BrowserIntroDialog />}
-                  storageProviders={storageProviders}
-                  getStorageProviderOperations={getStorageProviderOperations}
-                  resourceSources={browserResourceSources}
-                  resourceExternalEditors={browserResourceExternalEditors}
-                  extensionsLoader={makeExtensionsLoader({
-                    objectsEditorService: ObjectsEditorService,
-                    objectsRenderingService: ObjectsRenderingService,
-                    filterExamples: !Window.isDev(),
-                  })}
-                  initialFileMetadataToOpen={initialFileMetadataToOpen}
-                  unsavedChanges={unsavedChanges}
-                />
-              )}
-            </UnsavedChangesContext.Consumer>
+            <CommandsContextProvider>
+              <UnsavedChangesContext.Consumer>
+                {unsavedChanges => (
+                  <MainFrame
+                    i18n={i18n}
+                    eventsFunctionsExtensionsState={
+                      eventsFunctionsExtensionsState
+                    }
+                    renderPreviewLauncher={(props, ref) => (
+                      <BrowserS3PreviewLauncher {...props} ref={ref} />
+                    )}
+                    renderExportDialog={props => (
+                      <ExportDialog
+                        {...props}
+                        exporters={getBrowserExporters()}
+                        allExportersRequireOnline
+                      />
+                    )}
+                    renderCreateDialog={props => (
+                      <CreateProjectDialog
+                        {...props}
+                        examplesComponent={BrowserExamples}
+                        startersComponent={BrowserStarters}
+                      />
+                    )}
+                    introDialog={<BrowserIntroDialog />}
+                    storageProviders={storageProviders}
+                    getStorageProviderOperations={getStorageProviderOperations}
+                    resourceSources={browserResourceSources}
+                    resourceExternalEditors={browserResourceExternalEditors}
+                    extensionsLoader={makeExtensionsLoader({
+                      objectsEditorService: ObjectsEditorService,
+                      objectsRenderingService: ObjectsRenderingService,
+                      filterExamples: !Window.isDev(),
+                    })}
+                    initialFileMetadataToOpen={initialFileMetadataToOpen}
+                    unsavedChanges={unsavedChanges}
+                  />
+                )}
+              </UnsavedChangesContext.Consumer>
+            </CommandsContextProvider>
           )}
         </ProjectStorageProviders>
       )}

--- a/newIDE/app/src/CommandPanel/context.js
+++ b/newIDE/app/src/CommandPanel/context.js
@@ -1,0 +1,21 @@
+// @flow
+import * as React from 'react';
+import CommandManager from './manager';
+
+const manager = new CommandManager();
+export const CommandsContext = React.createContext<CommandManager>(manager);
+
+type Props = {
+  children: React.Node,
+};
+
+const CommandsContextProvider = (props: Props) => {
+  const manager = React.useRef(new CommandManager());
+  return (
+    <CommandsContext.Provider value={manager.current}>
+      {props.children}
+    </CommandsContext.Provider>
+  );
+};
+
+export default CommandsContextProvider;

--- a/newIDE/app/src/CommandPanel/hook.js
+++ b/newIDE/app/src/CommandPanel/hook.js
@@ -1,0 +1,19 @@
+// @flow
+import * as React from 'react';
+import { CommandsContext } from './context';
+import { type Command } from './manager';
+
+const useCommand = (cmd: Command) => {
+  const manager = React.useContext(CommandsContext);
+  console.log(manager.commands);
+
+  React.useEffect(
+    () => {
+      manager.register(cmd);
+      return () => manager.deregister(cmd.name);
+    },
+    [cmd.handler, cmd.enabled]
+  );
+};
+
+export default useCommand;

--- a/newIDE/app/src/CommandPanel/hook.js
+++ b/newIDE/app/src/CommandPanel/hook.js
@@ -3,14 +3,14 @@ import * as React from 'react';
 import { CommandsContext } from './context';
 import { type Command } from './manager';
 
-const useCommand = (cmd: Command) => {
+const useCommand = (cmdName: string, cmd: Command) => {
   const manager = React.useContext(CommandsContext);
   console.log(manager.commands);
 
   React.useEffect(
     () => {
-      manager.register(cmd);
-      return () => manager.deregister(cmd.name);
+      manager.register(cmdName, cmd);
+      return () => manager.deregister(cmdName);
     },
     [cmd.handler, cmd.enabled]
   );

--- a/newIDE/app/src/CommandPanel/hook.js
+++ b/newIDE/app/src/CommandPanel/hook.js
@@ -1,12 +1,10 @@
 // @flow
 import * as React from 'react';
 import { CommandsContext } from './context';
-import { type Command } from './manager';
+import { type Command, type OverrideOption } from './manager';
 
-const useCommand = (cmdName: string, cmd: Command) => {
+export const useCommand = (cmdName: string, cmd: Command) => {
   const manager = React.useContext(CommandsContext);
-  console.log(manager.commands);
-
   React.useEffect(
     () => {
       manager.register(cmdName, cmd);
@@ -16,4 +14,28 @@ const useCommand = (cmdName: string, cmd: Command) => {
   );
 };
 
-export default useCommand;
+export const useEnableGotoCommand = (cmdName: string, enabled: boolean) => {
+  const manager = React.useContext(CommandsContext);
+  React.useEffect(
+    () => {
+      if (enabled) manager.enableGotoCommand(cmdName);
+      return () => manager.disableGotoCommand(cmdName);
+    },
+    [cmdName, enabled]
+  );
+};
+
+export const useOverrideGotoCmdOptions = <T>(
+  cmdName: string,
+  options: Array<OverrideOption<T>>
+) => {
+  const manager = React.useContext(CommandsContext);
+  React.useEffect(
+    () => {
+      manager.overrideGotoCommandOptions(cmdName, options);
+      const optionVals = options.map(o => o.value);
+      return () => manager.withdrawGotoCommandOptions(cmdName, optionVals);
+    },
+    [cmdName, options]
+  );
+};

--- a/newIDE/app/src/CommandPanel/hook.js
+++ b/newIDE/app/src/CommandPanel/hook.js
@@ -14,14 +14,14 @@ export const useCommand = (cmdName: string, cmd: Command) => {
   );
 };
 
-export const useEnableGotoCommand = (cmdName: string, enabled: boolean) => {
+export const useEnableGotoCommands = (project: ?gdProject) => {
   const manager = React.useContext(CommandsContext);
   React.useEffect(
     () => {
-      if (enabled) manager.enableGotoCommand(cmdName);
-      return () => manager.disableGotoCommand(cmdName);
+      if (!!project) manager.initializeGotoCommands(project);
+      return () => manager.disableGotoCommands();
     },
-    [cmdName, enabled]
+    [project]
   );
 };
 

--- a/newIDE/app/src/CommandPanel/manager.js
+++ b/newIDE/app/src/CommandPanel/manager.js
@@ -1,9 +1,43 @@
 // @flow
 
+const sampleGotoCommand = {
+  text: 'Edit object variables...',
+  enabled: false,
+  options: [
+    {
+      value: 1,
+      baseHandler: () => console.log('Executed option 1'),
+      handler: null,
+    },
+    {
+      value: 2,
+      baseHandler: () => console.log('Executed option 2'),
+      handler: null,
+    },
+  ],
+};
+
 export type Command = {|
   text: string, // Display text
   enabled: boolean,
   handler: () => void | Promise<void>,
+|};
+
+export type Option<T> = {|
+  value: T,
+  baseHandler: () => void | Promise<void>,
+  handler: null | (() => void | Promise<void>),
+|};
+
+export type OverrideOption<T> = {|
+  value: T,
+  handler: () => void | Promise<void>,
+|};
+
+export type GotoCommand<T> = {|
+  text: string, // Display text
+  enabled: boolean,
+  options: Array<Option<T>>,
 |};
 
 export type UICommand = {|
@@ -15,10 +49,17 @@ export type UICommand = {|
 
 class CommandManager {
   commands: { [string]: Command };
+  gotoCommands: { [string]: GotoCommand<any> };
 
   constructor() {
     this.commands = {};
+    this.gotoCommands = {
+      // Simulate the base handler generator for now
+      EDIT_OBJ_VARS: sampleGotoCommand,
+    };
   }
+
+  // Basic commands
 
   _hasCmd(cmdName: string) {
     const cmd = this.commands[cmdName];
@@ -31,7 +72,7 @@ class CommandManager {
       return;
     }
     this.commands[cmdName] = cmd;
-    console.log(`New command '${cmdName}' registered!`);
+    console.warn(`New command '${cmdName}' registered!`);
   };
 
   execute = (cmdName: string) => {
@@ -41,7 +82,7 @@ class CommandManager {
       return;
     }
     cmd.handler && cmd.handler();
-    console.log(`Executed command ${cmdName}!`);
+    console.warn(`Executed command ${cmdName}!`);
   };
 
   deregister = (cmdName: string) => {
@@ -51,10 +92,74 @@ class CommandManager {
       return;
     }
     delete this.commands[cmdName];
-    console.log(`Command ${cmdName} unregistered!`);
+    console.warn(`Command ${cmdName} unregistered!`);
   };
 
+  // Goto Anything commands
+
+  enableGotoCommand = (cmdName: string) => {
+    const cmd = this.gotoCommands[cmdName];
+    if (!cmd) {
+      console.warn(`Command '${cmdName}' does not exist.`);
+      return;
+    }
+    cmd.enabled = true;
+    console.warn(`Enabled command '${cmdName}'`);
+  };
+
+  disableGotoCommand = (cmdName: string) => {
+    const cmd = this.gotoCommands[cmdName];
+    if (!cmd) {
+      console.warn(`Command '${cmdName}' does not exist.`);
+      return;
+    }
+    cmd.enabled = false;
+    console.warn(`Enabled command '${cmdName}'`);
+  };
+
+  overrideGotoCommandOptions = <T>(
+    cmdName: string,
+    options: Array<OverrideOption<T>>
+  ) => {
+    const cmd = this.gotoCommands[cmdName];
+    if (!cmd || !cmd.enabled) return console.warn('Not found or disabled');
+    // Override option handlers
+    options.forEach(opt => {
+      const cmdOpt = cmd.options.find(o => o.value === opt.value);
+      if (cmdOpt) {
+        // Change handler of option
+        cmdOpt.handler = opt.handler;
+        console.warn('Updated handler of gotocommand option', cmdOpt.value);
+      } else {
+        // Add new option to command
+        cmd.options.push({
+          ...opt,
+          baseHandler: () => console.warn('Executed option', opt.value), // To be obtained later from handler generator
+        });
+      }
+    });
+  };
+
+  withdrawGotoCommandOptions = <T>(cmdName: string, optionVals: Array<T>) => {
+    const cmd = this.gotoCommands[cmdName];
+    if (!cmd || !cmd.enabled) return console.warn('Not found or disabled');
+    // Withdraw option handlers
+    optionVals.forEach(val => {
+      const cmdOpt = cmd.options.find(o => o.value === val);
+      if (cmdOpt) {
+        cmdOpt.handler = null;
+        console.warn('Removed override of gotocommand option', cmdOpt.value);
+      } else {
+        // That's weird.
+        console.error('wat');
+      }
+    });
+  };
+
+  // Functions for the UI Component
+
   getAll = (): Array<UICommand> => {
+    // TODO: Add goto commands
     const commands = Object.keys(this.commands).map<UICommand>(cmdName => ({
       ...this.commands[cmdName],
       name: cmdName,
@@ -63,6 +168,7 @@ class CommandManager {
   };
 
   getEnabled = (): Array<UICommand> => {
+    // TODO: Add goto commands
     const commands = Object.keys(this.commands)
       .filter(name => this.commands[name].enabled)
       .map<UICommand>(cmdName => ({

--- a/newIDE/app/src/CommandPanel/manager.js
+++ b/newIDE/app/src/CommandPanel/manager.js
@@ -1,60 +1,75 @@
 // @flow
 
-export type Command = {
-  name: string, // Unique identifier
+export type Command = {|
   text: string, // Display text
   enabled: boolean,
   handler: () => void | Promise<void>,
-};
+|};
+
+export type UICommand = {|
+  name: string,
+  text: string, // Display text
+  enabled: boolean,
+  handler: () => void | Promise<void>,
+|};
 
 class CommandManager {
-  commands: Array<Command>;
+  commands: { [string]: Command };
 
   constructor() {
-    this.commands = [];
+    this.commands = {};
   }
 
   _hasCmd(cmdName: string) {
-    const cmdIdx = this.commands.findIndex(c => c.name === cmdName);
-    return cmdIdx !== -1;
+    const cmd = this.commands[cmdName];
+    return cmd !== undefined;
   }
 
-  register = (cmd: Command) => {
-    if (this._hasCmd(cmd.name)) {
-      console.warn(`Command '${cmd.name}' already exists.`);
+  register = (cmdName: string, cmd: Command) => {
+    if (this._hasCmd(cmdName)) {
+      console.warn(`Command '${cmdName}' already exists.`);
       return;
     }
-    this.commands.push(cmd);
-    console.log(`New command ${cmd.name} registered!`);
+    this.commands[cmdName] = cmd;
+    console.log(`New command '${cmdName}' registered!`);
   };
 
   execute = (cmdName: string) => {
-    const cmd = this.commands.find(c => c.name === cmdName);
+    const cmd = this.commands[cmdName];
     if (!cmd) {
       console.warn(`Command '${cmdName}' does not exist.`);
       return;
     }
     cmd.handler && cmd.handler();
-    console.log(`Executed command ${cmd.name}!`);
+    console.log(`Executed command ${cmdName}!`);
   };
 
   deregister = (cmdName: string) => {
-    const cmdIdx = this.commands.findIndex(c => c.name === cmdName);
-    if (cmdIdx === -1) {
+    const cmd = this.commands[cmdName];
+    if (!cmd) {
       console.warn(`Command '${cmdName}' does not exist.`);
       return;
     }
-    this.commands.splice(cmdIdx, 1);
+    delete this.commands[cmdName];
     console.log(`Command ${cmdName} unregistered!`);
   };
 
-  getAll = () => {
-    return this.commands;
+  getAll = (): Array<UICommand> => {
+    const commands = Object.keys(this.commands).map<UICommand>(cmdName => ({
+      ...this.commands[cmdName],
+      name: cmdName,
+    }));
+    return commands;
   };
 
-  getEnabled = (): Array<Command> => {
-    const enabledCommands = this.commands.filter(c => c.enabled);
-    return enabledCommands;
+  getEnabled = (): Array<UICommand> => {
+    const commands = Object.keys(this.commands)
+      .filter(name => this.commands[name].enabled)
+      .map<UICommand>(cmdName => ({
+        ...this.commands[cmdName],
+        name: cmdName,
+      }));
+    return commands;
   };
 }
 

--- a/newIDE/app/src/CommandPanel/manager.js
+++ b/newIDE/app/src/CommandPanel/manager.js
@@ -1,0 +1,61 @@
+// @flow
+
+export type Command = {
+  name: string, // Unique identifier
+  text: string, // Display text
+  enabled: boolean,
+  handler: () => void | Promise<void>,
+};
+
+class CommandManager {
+  commands: Array<Command>;
+
+  constructor() {
+    this.commands = [];
+  }
+
+  _hasCmd(cmdName: string) {
+    const cmdIdx = this.commands.findIndex(c => c.name === cmdName);
+    return cmdIdx !== -1;
+  }
+
+  register = (cmd: Command) => {
+    if (this._hasCmd(cmd.name)) {
+      console.warn(`Command '${cmd.name}' already exists.`);
+      return;
+    }
+    this.commands.push(cmd);
+    console.log(`New command ${cmd.name} registered!`);
+  };
+
+  execute = (cmdName: string) => {
+    const cmd = this.commands.find(c => c.name === cmdName);
+    if (!cmd) {
+      console.warn(`Command '${cmdName}' does not exist.`);
+      return;
+    }
+    cmd.handler && cmd.handler();
+    console.log(`Executed command ${cmd.name}!`);
+  };
+
+  deregister = (cmdName: string) => {
+    const cmdIdx = this.commands.findIndex(c => c.name === cmdName);
+    if (cmdIdx === -1) {
+      console.warn(`Command '${cmdName}' does not exist.`);
+      return;
+    }
+    this.commands.splice(cmdIdx, 1);
+    console.log(`Command ${cmdName} unregistered!`);
+  };
+
+  getAll = () => {
+    return this.commands;
+  };
+
+  getEnabled = (): Array<Command> => {
+    const enabledCommands = this.commands.filter(c => c.enabled);
+    return enabledCommands;
+  };
+}
+
+export default CommandManager;

--- a/newIDE/app/src/LocalApp.js
+++ b/newIDE/app/src/LocalApp.js
@@ -26,6 +26,7 @@ import ProjectStorageProviders from './ProjectsStorage/ProjectStorageProviders';
 import LocalFileStorageProvider from './ProjectsStorage/LocalFileStorageProvider';
 import { LocalGDJSDevelopmentWatcher } from './GameEngineFinder/LocalGDJSDevelopmentWatcher';
 import UnsavedChangesContext from './MainFrame/UnsavedChangesContext';
+import CommandsContextProvider from './CommandPanel/context';
 
 const gd = global.gd;
 
@@ -54,45 +55,50 @@ export const create = (authentification: Authentification) => {
             storageProviders,
             initialFileMetadataToOpen,
           }) => (
-            <UnsavedChangesContext.Consumer>
-              {unsavedChanges => (
-                <MainFrame
-                  i18n={i18n}
-                  renderMainMenu={props => <ElectronMainMenu {...props} />}
-                  eventsFunctionsExtensionsState={
-                    eventsFunctionsExtensionsState
-                  }
-                  renderPreviewLauncher={(props, ref) => (
-                    <LocalPreviewLauncher {...props} ref={ref} />
-                  )}
-                  renderExportDialog={props => (
-                    <ExportDialog {...props} exporters={getLocalExporters()} />
-                  )}
-                  renderCreateDialog={props => (
-                    <CreateProjectDialog
-                      {...props}
-                      examplesComponent={LocalExamples}
-                      startersComponent={LocalStarters}
-                    />
-                  )}
-                  renderGDJSDevelopmentWatcher={
-                    isDev ? () => <LocalGDJSDevelopmentWatcher /> : null
-                  }
-                  storageProviders={storageProviders}
-                  getStorageProviderOperations={getStorageProviderOperations}
-                  resourceSources={localResourceSources}
-                  resourceExternalEditors={localResourceExternalEditors}
-                  extensionsLoader={makeExtensionsLoader({
-                    gd,
-                    objectsEditorService: ObjectsEditorService,
-                    objectsRenderingService: ObjectsRenderingService,
-                    filterExamples: !isDev,
-                  })}
-                  initialFileMetadataToOpen={initialFileMetadataToOpen}
-                  unsavedChanges={unsavedChanges}
-                />
-              )}
-            </UnsavedChangesContext.Consumer>
+            <CommandsContextProvider>
+              <UnsavedChangesContext.Consumer>
+                {unsavedChanges => (
+                  <MainFrame
+                    i18n={i18n}
+                    renderMainMenu={props => <ElectronMainMenu {...props} />}
+                    eventsFunctionsExtensionsState={
+                      eventsFunctionsExtensionsState
+                    }
+                    renderPreviewLauncher={(props, ref) => (
+                      <LocalPreviewLauncher {...props} ref={ref} />
+                    )}
+                    renderExportDialog={props => (
+                      <ExportDialog
+                        {...props}
+                        exporters={getLocalExporters()}
+                      />
+                    )}
+                    renderCreateDialog={props => (
+                      <CreateProjectDialog
+                        {...props}
+                        examplesComponent={LocalExamples}
+                        startersComponent={LocalStarters}
+                      />
+                    )}
+                    renderGDJSDevelopmentWatcher={
+                      isDev ? () => <LocalGDJSDevelopmentWatcher /> : null
+                    }
+                    storageProviders={storageProviders}
+                    getStorageProviderOperations={getStorageProviderOperations}
+                    resourceSources={localResourceSources}
+                    resourceExternalEditors={localResourceExternalEditors}
+                    extensionsLoader={makeExtensionsLoader({
+                      gd,
+                      objectsEditorService: ObjectsEditorService,
+                      objectsRenderingService: ObjectsRenderingService,
+                      filterExamples: !isDev,
+                    })}
+                    initialFileMetadataToOpen={initialFileMetadataToOpen}
+                    unsavedChanges={unsavedChanges}
+                  />
+                )}
+              </UnsavedChangesContext.Consumer>
+            </CommandsContextProvider>
           )}
         </ProjectStorageProviders>
       )}

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -228,8 +228,7 @@ const MainFrame = (props: Props) => {
     [state.currentProject]
   );
 
-  useCommand({
-    name: 'SOME_COMMAND',
+  useCommand('SOME_COMMAND', {
     text: 'Do something great',
     enabled: true,
     handler: sampleCmdHandler,
@@ -1350,8 +1349,7 @@ const MainFrame = (props: Props) => {
     return closeProject();
   };
 
-  useCommand({
-    name: 'CLOSE_PROJECT',
+  useCommand('CLOSE_PROJECT', {
     text: 'Close the current project',
     enabled: !!state.currentProject,
     handler: askToCloseProject,

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -100,7 +100,7 @@ import { type MainMenuProps } from './MainMenu.flow';
 import useForceUpdate from '../Utils/UseForceUpdate';
 import useStateWithCallback from '../Utils/UseSetStateWithCallback';
 import { type PreviewState } from './PreviewState.flow';
-import useCommand from '../CommandPanel/hook';
+import { useCommand, useEnableGotoCommand } from '../CommandPanel/hook';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 
@@ -233,6 +233,8 @@ const MainFrame = (props: Props) => {
     enabled: true,
     handler: sampleCmdHandler,
   });
+
+  useEnableGotoCommand('EDIT_OBJ_VARS', !!state.currentProject);
 
   // This is just for testing, to check if we're getting the right state
   // and gives us an idea about the number of re-renders.

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -100,6 +100,7 @@ import { type MainMenuProps } from './MainMenu.flow';
 import useForceUpdate from '../Utils/UseForceUpdate';
 import useStateWithCallback from '../Utils/UseSetStateWithCallback';
 import { type PreviewState } from './PreviewState.flow';
+import useCommand from '../CommandPanel/hook';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 
@@ -219,6 +220,20 @@ const MainFrame = (props: Props) => {
   const preferences = React.useContext(PreferencesContext);
   const [previewLoading, setPreviewLoading] = React.useState<boolean>(false);
   const [previewState, setPreviewState] = React.useState(initialPreviewState);
+
+  const sampleCmdHandler = React.useCallback(
+    () => {
+      console.log('Hello');
+    },
+    [state.currentProject]
+  );
+
+  useCommand({
+    name: 'SOME_COMMAND',
+    text: 'Do something great',
+    enabled: true,
+    handler: sampleCmdHandler,
+  });
 
   // This is just for testing, to check if we're getting the right state
   // and gives us an idea about the number of re-renders.
@@ -1334,6 +1349,13 @@ const MainFrame = (props: Props) => {
     }
     return closeProject();
   };
+
+  useCommand({
+    name: 'CLOSE_PROJECT',
+    text: 'Close the current project',
+    enabled: !!state.currentProject,
+    handler: askToCloseProject,
+  });
 
   const openSceneOrProjectManager = (
     newState = {

--- a/newIDE/app/src/MainFrame/index.js
+++ b/newIDE/app/src/MainFrame/index.js
@@ -100,7 +100,7 @@ import { type MainMenuProps } from './MainMenu.flow';
 import useForceUpdate from '../Utils/UseForceUpdate';
 import useStateWithCallback from '../Utils/UseSetStateWithCallback';
 import { type PreviewState } from './PreviewState.flow';
-import { useCommand, useEnableGotoCommand } from '../CommandPanel/hook';
+import { useCommand, useEnableGotoCommands } from '../CommandPanel/hook';
 
 const GD_STARTUP_TIMES = global.GD_STARTUP_TIMES || [];
 
@@ -230,11 +230,11 @@ const MainFrame = (props: Props) => {
 
   useCommand('SOME_COMMAND', {
     text: 'Do something great',
-    enabled: true,
+    enabled: !!state.currentProject,
     handler: sampleCmdHandler,
   });
 
-  useEnableGotoCommand('EDIT_OBJ_VARS', !!state.currentProject);
+  useEnableGotoCommands(state.currentProject);
 
   // This is just for testing, to check if we're getting the right state
   // and gives us an idea about the number of re-renders.
@@ -1350,12 +1350,6 @@ const MainFrame = (props: Props) => {
     }
     return closeProject();
   };
-
-  useCommand('CLOSE_PROJECT', {
-    text: 'Close the current project',
-    enabled: !!state.currentProject,
-    handler: askToCloseProject,
-  });
 
   const openSceneOrProjectManager = (
     newState = {

--- a/newIDE/app/src/ObjectsList/index.js
+++ b/newIDE/app/src/ObjectsList/index.js
@@ -36,6 +36,7 @@ import {
   getTagsFromString,
 } from '../Utils/TagsHelper';
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
+import CommandManager from '../CommandPanel/manager';
 
 const styles = {
   listContainer: {
@@ -99,6 +100,7 @@ type Props = {|
 
   getThumbnail: (project: gdProject, object: Object) => string,
   unsavedChanges?: ?UnsavedChanges,
+  cmdManager: CommandManager,
 |};
 
 export default class ObjectsList extends React.Component<Props, State> {
@@ -143,6 +145,17 @@ export default class ObjectsList extends React.Component<Props, State> {
       return true;
 
     return false;
+  }
+
+  componentDidMount() {
+    this.props.cmdManager.overrideGotoCommandOptions('EDIT_OBJ_VARS', [
+      { handler: () => console.log('Overridden 1'), value: 1 },
+      { handler: () => console.log('Overridden 3'), value: 3 },
+    ]);
+  }
+
+  componentWillUnmount() {
+    this.props.cmdManager.withdrawGotoCommandOptions('EDIT_OBJ_VARS', [1, 3]);
   }
 
   addObject = (objectType: string) => {

--- a/newIDE/app/src/SceneEditor/index.js
+++ b/newIDE/app/src/SceneEditor/index.js
@@ -66,6 +66,7 @@ import { ResponsiveWindowMeasurer } from '../UI/Reponsive/ResponsiveWindowMeasur
 import { type UnsavedChanges } from '../MainFrame/UnsavedChangesContext';
 import SceneVariablesDialog from './SceneVariablesDialog';
 import PreferencesContext from '../MainFrame/Preferences/PreferencesContext';
+import { CommandsContext } from '../CommandPanel/context';
 const gd = global.gd;
 
 const INSTANCES_CLIPBOARD_KIND = 'Instances';
@@ -984,30 +985,35 @@ export default class SceneEditor extends React.Component<Props, State> {
           <CloseButton key="close" />,
         ],
         renderEditor: () => (
-          <ObjectsList
-            getThumbnail={ObjectsRenderingService.getThumbnail.bind(
-              ObjectsRenderingService
+          <CommandsContext.Consumer>
+            {cmdManager => (
+              <ObjectsList
+                getThumbnail={ObjectsRenderingService.getThumbnail.bind(
+                  ObjectsRenderingService
+                )}
+                project={project}
+                cmdManager={cmdManager}
+                objectsContainer={layout}
+                selectedObjectNames={this.state.selectedObjectNames}
+                onEditObject={this.props.onEditObject || this.editObject}
+                onDeleteObject={this._onDeleteObject}
+                canRenameObject={this._canObjectOrGroupUseNewName}
+                onObjectCreated={this._addInstanceForNewObject}
+                onObjectSelected={this._onObjectSelected}
+                onRenameObject={this._onRenameObject}
+                onObjectPasted={() => this.updateBehaviorsSharedData()}
+                selectedObjectTags={this.state.selectedObjectTags}
+                onChangeSelectedObjectTags={selectedObjectTags =>
+                  this.setState({
+                    selectedObjectTags,
+                  })
+                }
+                getAllObjectTags={this._getAllObjectTags}
+                ref={objectsList => (this._objectsList = objectsList)}
+                unsavedChanges={this.props.unsavedChanges}
+              />
             )}
-            project={project}
-            objectsContainer={layout}
-            selectedObjectNames={this.state.selectedObjectNames}
-            onEditObject={this.props.onEditObject || this.editObject}
-            onDeleteObject={this._onDeleteObject}
-            canRenameObject={this._canObjectOrGroupUseNewName}
-            onObjectCreated={this._addInstanceForNewObject}
-            onObjectSelected={this._onObjectSelected}
-            onRenameObject={this._onRenameObject}
-            onObjectPasted={() => this.updateBehaviorsSharedData()}
-            selectedObjectTags={this.state.selectedObjectTags}
-            onChangeSelectedObjectTags={selectedObjectTags =>
-              this.setState({
-                selectedObjectTags,
-              })
-            }
-            getAllObjectTags={this._getAllObjectTags}
-            ref={objectsList => (this._objectsList = objectsList)}
-            unsavedChanges={this.props.unsavedChanges}
-          />
+          </CommandsContext.Consumer>
         ),
       },
       'object-groups-list': {

--- a/newIDE/app/src/index.js
+++ b/newIDE/app/src/index.js
@@ -54,7 +54,9 @@ class Bootstrapper extends Component<{}, State> {
     GD_STARTUP_TIMES.push(['bootstrapperComponentDidMount', performance.now()]);
 
     // Load GDevelop.js, ensuring a new version is fetched when the version changes.
-    loadScript(`./libGD.js?cache-buster=${VersionMetadata.versionWithHash}`).then(() => {
+    loadScript(
+      `./libGD.js?cache-buster=${VersionMetadata.versionWithHash}`
+    ).then(() => {
       GD_STARTUP_TIMES.push(['libGDLoadedTime', performance.now()]);
       const initializeGDevelopJs = global.initializeGDevelopJs;
       if (!initializeGDevelopJs) {
@@ -94,7 +96,7 @@ class Bootstrapper extends Component<{}, State> {
     }, this.handleEditorLoadError);
   }
 
-  handleEditorLoadError = (err) => {
+  handleEditorLoadError = err => {
     const message = !electron
       ? 'Please check your internet connectivity, close the tab and reopen it.'
       : 'Please restart the application or reinstall the latest version if the problem persists.';
@@ -103,7 +105,7 @@ class Bootstrapper extends Component<{}, State> {
       loadingMessage: `Unable to load GDevelop. ${message}`,
     });
     showErrorBox(`Unable to load GDevelop. ${message}`, err);
-  }
+  };
 
   render() {
     const { App, loadingMessage } = this.state;


### PR DESCRIPTION
@4ian I've created a very barebones prototype for simple commands. The code is not very clean, as it's just a prototype for now. I'll add a prototype for Goto Anything commands in a few days.

- For now, I've created a separate context provider component in `CommandPanel/context.js`, and used it in both BrowserApp and LocalApp. Later, I guess we can move it into the Providers component.

- I've added two commands in Mainframe. Everything seems to work - the `enabled` property of commands is being updated properly and handlers are updated if the handling function changes (the sample Close Project command gets updated on each Mainframe rerender due to the point mentioned below).

- Some functions in Mainframe haven't been wrapped in a `useCallback` (for eg, `askToCloseProject`). These functions are also used in ElectronMainMenu, which means some IPC listeners are probably reset on every Mainframe render. Doesn't break anything (thanks to the custom hook in ElectronMainMenu) but still, that should be fixed, right?

This PR is just a discussion thread for the prototyping period. I guess we can shift to a proper draft PR in the main repo when the coding period starts, if that's okay.